### PR TITLE
Make restrictions closer to vanilla

### DIFF
--- a/common/decisions/bmvd_decision.txt
+++ b/common/decisions/bmvd_decision.txt
@@ -178,7 +178,12 @@
 				scope:mod_improve_cultural_acceptance ?= {
 					if = {
 						limit = {
-							highest_held_title_tier >= tier_duchy
+							AND = {
+								highest_held_title_tier >= tier_duchy
+								any_sub_realm_county = {
+									culture != prev.culture
+								}
+							}
 						}
 					remove_vassal_directives = yes
 					custom_tooltip = mod_improve_cultural_acceptance_tooltip

--- a/common/decisions/bmvd_decision.txt
+++ b/common/decisions/bmvd_decision.txt
@@ -116,32 +116,58 @@
 				}
 				
 				scope:mod_convert_faith ?= {
-					remove_vassal_directives = yes
-					custom_tooltip = mod_new_decision_convert_faith_tooltip
-					add_character_flag = vassal_directive_convert_faith
+					if = {
+						limit = {
+							any_sub_realm_county = {
+								faith != prev.faith
+							}
+						}
+						remove_vassal_directives = yes
+						custom_tooltip = mod_new_decision_convert_faith_tooltip
+						add_character_flag = vassal_directive_convert_faith
+					}
 				}
 				
 				scope:mod_convert_faith_own ?= {
 					if = {
 						limit = { 
-							faith = root.faith
+							AND = {
+								faith = root.faith
+							
+								any_sub_realm_county = {
+									faith != prev.faith
+								}	
+							}
 						}
-					remove_vassal_directives = yes
-					custom_tooltip = mod_new_decision_convert_faith_tooltip
-					add_character_flag = vassal_directive_convert_faith
+						remove_vassal_directives = yes
+						custom_tooltip = mod_new_decision_convert_faith_tooltip
+						add_character_flag = vassal_directive_convert_faith
 					}
 				}
 				
 				scope:mod_convert_culture ?= {
-					remove_vassal_directives = yes
-					custom_tooltip = mod_new_decision_convert_culture_tooltip
-					add_character_flag = vassal_directive_convert_culture
+					if = {
+						limit = {
+							any_sub_realm_county = {
+								culture != prev.culture
+							}
+						}
+						remove_vassal_directives = yes
+						custom_tooltip = mod_new_decision_convert_culture_tooltip
+						add_character_flag = vassal_directive_convert_culture
+					}
 				}
 				
 				scope:mod_convert_culture_own ?= {
 					if = {
 						limit = { 
-							culture = root.culture
+							AND = {
+								culture = root.culture
+							
+								any_sub_realm_county = {
+									culture != prev.culture
+								}	
+							}
 						}
 					remove_vassal_directives = yes
 					custom_tooltip = mod_new_decision_convert_culture_tooltip


### PR DESCRIPTION
In vanilla you are not allowed to direct vassals to convert faith or promote culture if their realm is already fully converted.
<img width="450" height="113" alt="image" src="https://github.com/user-attachments/assets/e43e38ac-ff6c-45df-a1ac-2d910949d272" />

Probably doesn't need any localization changes.